### PR TITLE
fix: correct Dependabot configuration update-types values

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -39,7 +39,8 @@ updates:
           - "golang.org/x/net*"
           - "golang.org/x/sys*"
         update-types:
-          - "security"
+          - "patch"
+          - "minor"
       test-dependencies:
         patterns:
           - "github.com/stretchr/testify*"
@@ -47,13 +48,11 @@ updates:
     # Enhanced security focus for 2025
     allow:
       - dependency-type: "direct"
-        update-type: "security"
-      - dependency-type: "indirect"  
-        update-type: "security"
-      - dependency-type: "direct"
         update-type: "version-update:semver-patch"
       - dependency-type: "direct"
         update-type: "version-update:semver-minor"
+      - dependency-type: "indirect"
+        update-type: "version-update:semver-patch"
     ignore:
       # Ignore major version updates for stability
       - dependency-name: "google.golang.org/grpc"


### PR DESCRIPTION
- Change invalid "security" update-type to valid "patch" and "minor"
- Remove invalid "security" entries from allow section
- Ensure all update-types use proper semver format

🤖 Generated with [Claude Code](https://claude.ai/code)