### PR TITLE
Fix invalid workflow syntax in security.yml

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -457,7 +457,7 @@ jobs:
   container-security:
     name: Container Security Scan
     runs-on: ubuntu-latest
-    if: hashFiles('Dockerfile', '**/Dockerfile') != ''
+    if: ${{ hashFiles('Dockerfile', '**/Dockerfile') != '' }}
     steps:
     - name: Checkout code
       uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7


### PR DESCRIPTION
Fix hashFiles function syntax error at line 460 by wrapping in expression evaluation syntax.

Changes:
- Change: if: hashFiles('Dockerfile', '**/Dockerfile') \!= ''
- To: if: ${{ hashFiles('Dockerfile', '**/Dockerfile') \!= '' }}
- Proper GitHub Actions expression syntax for conditional evaluation

This resolves the "Unrecognized function: 'hashFiles'" error that was preventing the security workflow from running.

🤖 Generated with [Claude Code](https://claude.ai/code)