### PR TITLE
fix: enable security fuzzing and SAST scanning on all CI/CD triggers

### DIFF
--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -116,7 +116,8 @@ jobs:
     name: ClusterFuzzLite
     runs-on: ubuntu-latest
     timeout-minutes: 45
-    if: github.event_name == 'schedule' || github.event_name == 'push'
+    # Run on all triggers (push, PR, schedule) to ensure comprehensive security testing
+    if: github.event_name == 'schedule' || github.event_name == 'push' || github.event_name == 'pull_request'
     permissions:
       contents: read
       security-events: write

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -9,6 +9,13 @@ on:
     paths:
       - 'go.mod'
       - 'go.sum'
+  pull_request:
+    branches: [ main ]
+    paths:
+      - 'go.mod'
+      - 'go.sum'
+      - '**/*.go'
+      - '.github/workflows/**'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
**Problem:**
1. ClusterFuzzLite was being skipped on pull requests due to conditional trigger
2. Security workflow (including sast-scan) was not running on PRs, causing "configuration not found" warnings in code scanning

**Changes made:**

1. **Fuzzing workflow (.github/workflows/fuzzing.yml):**
   - Added pull_request trigger to ClusterFuzzLite job
   - Now runs on push, PR, and schedule (comprehensive security testing)
   - Ensures fuzz testing happens before code merges

2. **Security workflow (.github/workflows/security.yml):**
   - Added pull_request trigger with relevant path filters
   - Includes Go files, go.mod/go.sum, and workflow changes
   - SAST scan (sast-scan job) now available on all PR triggers
   - Prevents "Actions workflow (security.yml):sast-scan configuration not found" warnings

**Security Impact:**
- ✅ Fuzzing now runs on every PR (catches issues before merge)
- ✅ SAST scanning available for all pull requests
- ✅ No more missing sast-scan configuration warnings
- ✅ Enhanced security posture with comprehensive CI/CD coverage

**OpenSSF Scorecard Impact:**
- Improves fuzzing score (runs on all triggers)
- Enhances SAST coverage score
- Better overall security automation

Addresses: ClusterFuzzLite skipping + missing sast-scan configuration

🤖 Generated with [Claude Code](https://claude.ai/code)