### PR TITLE
refactor: Remove all authorization-related code, focus on pure authen…

### DIFF
--- a/cmd/config-validator/main.go
+++ b/cmd/config-validator/main.go
@@ -65,24 +65,6 @@ func displayConfiguration(cfg *ports.Configuration) {
 	if cfg.SPIFFE != nil {
 		fmt.Printf("   SPIFFE Socket: %s\n", cfg.SPIFFE.SocketPath)
 	}
-
-	if len(cfg.AuthorizedClients) > 0 {
-		fmt.Printf("   Authorized Clients: %d configured\n", len(cfg.AuthorizedClients))
-		for i, client := range cfg.AuthorizedClients {
-			fmt.Printf("     %d. %s\n", i+1, client)
-		}
-	} else {
-		fmt.Println("   Authorized Clients: None (allows all clients)")
-	}
-
-	if len(cfg.TrustedServers) > 0 {
-		fmt.Printf("   Trusted Servers: %d configured\n", len(cfg.TrustedServers))
-		for i, server := range cfg.TrustedServers {
-			fmt.Printf("     %d. %s\n", i+1, server)
-		}
-	} else {
-		fmt.Println("   Trusted Servers: None (trusts all servers)")
-	}
 }
 
 func printProductionTips(err error) {
@@ -125,7 +107,6 @@ func printSecurityRecommendations(envOnly bool) {
 
 	fmt.Println("  🛡️ Optional security environment variables:")
 	fmt.Printf("     export %s=\"/run/spire/sockets/api.sock\"\n", ports.EnvSPIFFESocket)
-	fmt.Printf("     export %s=\"spiffe://your.domain/client1,spiffe://your.domain/client2\"\n", ports.EnvAuthorizedClients)
 	fmt.Printf("     export %s=\"false\"\n", ports.EnvDebugEnabled)
 
 	fmt.Println("  📚 For more details, see:")

--- a/config/ephemos.yaml
+++ b/config/ephemos.yaml
@@ -5,9 +5,3 @@ service:
 # Optional - sensible defaults if not specified
 spiffe:
   socketPath: "/tmp/spire-agent/public/api.sock"
-  
-# For server: which clients can connect
-authorized_clients: []
-  
-# For client: which servers to trust (optional)  
-trusted_servers: []

--- a/internal/adapters/secondary/config/inmemory_provider.go
+++ b/internal/adapters/secondary/config/inmemory_provider.go
@@ -105,15 +105,5 @@ func copyConfiguration(config *ports.Configuration) *ports.Configuration {
 		}
 	}
 
-	if config.AuthorizedClients != nil {
-		cfgCopy.AuthorizedClients = make([]string, len(config.AuthorizedClients))
-		cfgCopy.AuthorizedClients = append(cfgCopy.AuthorizedClients, config.AuthorizedClients...)
-	}
-
-	if config.TrustedServers != nil {
-		cfgCopy.TrustedServers = make([]string, len(config.TrustedServers))
-		cfgCopy.TrustedServers = append(cfgCopy.TrustedServers, config.TrustedServers...)
-	}
-
 	return cfgCopy
 }

--- a/internal/adapters/secondary/config/provider.go
+++ b/internal/adapters/secondary/config/provider.go
@@ -85,7 +85,5 @@ func (p *FileProvider) GetDefaultConfiguration(_ context.Context) *ports.Configu
 		SPIFFE: &ports.SPIFFEConfig{
 			SocketPath: "/tmp/spire-agent/public/api.sock", // Standard SPIRE agent socket path
 		},
-		AuthorizedClients: []string{}, // Empty list - no client restrictions by default
-		TrustedServers:    []string{}, // Empty list - trust all servers by default (not recommended for production)
 	}
 }

--- a/internal/core/domain/identity.go
+++ b/internal/core/domain/identity.go
@@ -45,54 +45,15 @@ type TrustBundle struct {
 	Certificates []*x509.Certificate
 }
 
-// AuthenticationPolicy defines auth rules.
+// AuthenticationPolicy defines authentication context.
+// This is now purely for identity-based authentication without authorization.
 type AuthenticationPolicy struct {
-	ServiceIdentity   *ServiceIdentity
-	AuthorizedClients []string
-	TrustedServers    []string
+	ServiceIdentity *ServiceIdentity
 }
 
-// NewAuthenticationPolicy creates a policy.
+// NewAuthenticationPolicy creates a policy for authentication.
 func NewAuthenticationPolicy(identity *ServiceIdentity) *AuthenticationPolicy {
 	return &AuthenticationPolicy{
-		ServiceIdentity:   identity,
-		AuthorizedClients: []string{},
-		TrustedServers:    []string{},
+		ServiceIdentity: identity,
 	}
-}
-
-// AddAuthorizedClient adds a client.
-func (p *AuthenticationPolicy) AddAuthorizedClient(clientName string) {
-	p.AuthorizedClients = append(p.AuthorizedClients, clientName)
-}
-
-// AddTrustedServer adds a server.
-func (p *AuthenticationPolicy) AddTrustedServer(serverName string) {
-	p.TrustedServers = append(p.TrustedServers, serverName)
-}
-
-// IsClientAuthorized checks client.
-func (p *AuthenticationPolicy) IsClientAuthorized(clientName string) bool {
-	if len(p.AuthorizedClients) == 0 {
-		return true
-	}
-	for _, authorized := range p.AuthorizedClients {
-		if authorized == clientName {
-			return true
-		}
-	}
-	return false
-}
-
-// IsServerTrusted checks server.
-func (p *AuthenticationPolicy) IsServerTrusted(serverName string) bool {
-	if len(p.TrustedServers) == 0 {
-		return true
-	}
-	for _, trusted := range p.TrustedServers {
-		if trusted == serverName {
-			return true
-		}
-	}
-	return false
 }

--- a/internal/core/services/identity_service.go
+++ b/internal/core/services/identity_service.go
@@ -95,7 +95,6 @@ func NewIdentityService(
 func (s *IdentityService) CreateServerIdentity() (ports.Server, error) {
 	s.mu.RLock()
 	identity := s.cachedIdentity
-	config := s.config
 	s.mu.RUnlock()
 
 	cert, err := s.getCertificate()
@@ -108,10 +107,8 @@ func (s *IdentityService) CreateServerIdentity() (ports.Server, error) {
 		return nil, fmt.Errorf("failed to get trust bundle for service %s: %w", identity.Name, err)
 	}
 
+	// Create authentication policy without authorization
 	policy := domain.NewAuthenticationPolicy(identity)
-	for _, client := range config.AuthorizedClients {
-		policy.AddAuthorizedClient(client)
-	}
 
 	server, err := s.transportProvider.CreateServer(cert, trustBundle, policy)
 	if err != nil {
@@ -127,7 +124,6 @@ func (s *IdentityService) CreateServerIdentity() (ports.Server, error) {
 func (s *IdentityService) CreateClientIdentity() (ports.Client, error) {
 	s.mu.RLock()
 	identity := s.cachedIdentity
-	config := s.config
 	s.mu.RUnlock()
 
 	cert, err := s.getCertificate()
@@ -140,10 +136,8 @@ func (s *IdentityService) CreateClientIdentity() (ports.Client, error) {
 		return nil, fmt.Errorf("failed to get trust bundle for service %s: %w", identity.Name, err)
 	}
 
+	// Create authentication policy without authorization
 	policy := domain.NewAuthenticationPolicy(identity)
-	for _, server := range config.TrustedServers {
-		policy.AddTrustedServer(server)
-	}
 
 	client, err := s.transportProvider.CreateClient(cert, trustBundle, policy)
 	if err != nil {


### PR DESCRIPTION
…tication

- Removed AuthorizedClients and TrustedServers from Configuration struct
- Simplified AuthenticationPolicy to only handle identity without authorization
- Updated transport layer to use tlsconfig.AuthorizeAny() for pure AuthN
- Removed authorization validation and filtering logic
- Updated tests to remove authorization-related test cases
- Simplified configuration files and examples

This refactor aligns with go-spiffe best practices where:
- Authentication (AuthN) verifies identity via SPIFFE SVIDs
- Authorization (AuthZ) is a separate concern to be handled externally
- Transport uses AuthorizeAny() to accept any valid authenticated identity