### PR TITLE
feat: Add OpenSSF Scorecard badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Ephemos
 
+[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/sufield/ephemos/badge)](https://securityscorecards.dev/viewer/?uri=github.com/sufield/ephemos)
+
 **No more plaintext API keys or secrets between your services.** Ephemos handles service-to-service authentication automatically using certificates that rotate every hour - so you never have to manage, store, or worry about API keys again.
 
 ## The Problem with API Keys


### PR DESCRIPTION
- Added OpenSSF Scorecard badge at the top of README
- Badge displays current security score from scorecard.dev
- Links to detailed scorecard report for transparency
- Scorecard workflow already configured in .github/workflows/scorecard.yml
- Helps demonstrate project's security posture to users

The scorecard runs weekly and on pushes to main branch, evaluating:
- Security policies
- Dependency management
- CI/CD practices
- Vulnerability scanning
- Code review processes