### PR TITLE
fix: Remove binary artifacts to address OpenSSF Scorecard security co…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,8 @@ cli.test
 interceptors.test
 ports.test
 *.test
+test-*
+*-test
 
 # Go build artifacts and executables (any name without extension in project root)
 /config-patterns


### PR DESCRIPTION
…ncern

Security Issue: Binary-Artifacts (High Risk)
- Binary artifacts cannot be reviewed and may contain malicious code
- Generated executables can become obsolete or subverted over time
- Including binaries in source repo increases user risk

Changes made:
- Removed tracked test binaries: test-config-validator, test-errorx
- Cleaned up untracked binaries: api.test, ephemos.test, config-validator, act
- Removed binary archive: act.tar.gz
- Enhanced .gitignore with test-* and *-test patterns

All binaries should be built from source using:
- 'go build ./...' for main binaries
- 'go test -c' for test binaries (temporary, not committed)
- 'make build' for project build process

This ensures:
✅ No binary artifacts in repository
✅ All executables built from reviewable source
✅ Build process cannot atrophy
✅ Reproducible builds from source