### PR TITLE
Fix GitHub workflow checkout for fork pull requests

### DIFF
--- a/.github/workflows/docs-and-release.yml
+++ b/.github/workflows/docs-and-release.yml
@@ -20,8 +20,20 @@ jobs:
     name: Documentation Lint
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout code
+    # PR path: checkout the fork + branch that opened the PR
+    - name: Checkout PR head
+      if: github.event_name == 'pull_request'
       uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      with:
+        repository: ${{ github.event.pull_request.head.repo.full_name }}
+        ref: ${{ github.event.pull_request.head.ref }}
+
+    # Push path: checkout this repo/branch
+    - name: Checkout push ref
+      if: github.event_name != 'pull_request'
+      uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      with:
+        ref: ${{ github.ref }}
       
     - name: Setup Node.js
       uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
@@ -49,8 +61,20 @@ jobs:
     name: Generate API Documentation
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout code
+    # PR path: checkout the fork + branch that opened the PR
+    - name: Checkout PR head
+      if: github.event_name == 'pull_request'
       uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      with:
+        repository: ${{ github.event.pull_request.head.repo.full_name }}
+        ref: ${{ github.event.pull_request.head.ref }}
+
+    # Push path: checkout this repo/branch
+    - name: Checkout push ref
+      if: github.event_name != 'pull_request'
+      uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      with:
+        ref: ${{ github.ref }}
       
     - name: Set up Go
       uses: actions/setup-go@v5
@@ -99,8 +123,20 @@ jobs:
     name: Validate Configurations
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout code
+    # PR path: checkout the fork + branch that opened the PR
+    - name: Checkout PR head
+      if: github.event_name == 'pull_request'
       uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      with:
+        repository: ${{ github.event.pull_request.head.repo.full_name }}
+        ref: ${{ github.event.pull_request.head.ref }}
+
+    # Push path: checkout this repo/branch
+    - name: Checkout push ref
+      if: github.event_name != 'pull_request'
+      uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      with:
+        ref: ${{ github.ref }}
       
     - name: Set up Go
       uses: actions/setup-go@v5

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -17,9 +17,21 @@ jobs:
     name: Benchmark Tests
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout code
+      # PR path: checkout the fork + branch that opened the PR
+      - name: Checkout PR head
+        if: github.event_name == 'pull_request'
         uses: actions/checkout@v4
         with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.ref }}
+          fetch-depth: 0
+
+      # Push path: checkout this repo/branch
+      - name: Checkout push ref
+        if: github.event_name != 'pull_request'
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref }}
           fetch-depth: 0
       - name: Set up Go
         uses: actions/setup-go@v5
@@ -98,8 +110,20 @@ jobs:
     name: Memory Baseline Testing
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout code
+      # PR path: checkout the fork + branch that opened the PR
+      - name: Checkout PR head
+        if: github.event_name == 'pull_request'
         uses: actions/checkout@v4
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.ref }}
+
+      # Push path: checkout this repo/branch
+      - name: Checkout push ref
+        if: github.event_name != 'pull_request'
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref }}
       - name: Set up Go
         uses: actions/setup-go@v5
         with:

--- a/.github/workflows/sast-scan.yml
+++ b/.github/workflows/sast-scan.yml
@@ -26,8 +26,20 @@ jobs:
       security-events: write
 
     steps:
-      - name: Checkout code
+      # PR path: checkout the fork + branch that opened the PR
+      - name: Checkout PR head
+        if: github.event_name == 'pull_request'
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.ref }}
+
+      # Push path: checkout this repo/branch
+      - name: Checkout push ref
+        if: github.event_name != 'pull_request'
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          ref: ${{ github.ref }}
 
       - name: Set up Go
         uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2

--- a/.github/workflows/secrets-scan.yml
+++ b/.github/workflows/secrets-scan.yml
@@ -29,12 +29,22 @@ jobs:
       security-events: write
       actions: read
     steps:
-    - name: Checkout code
+    # PR path: checkout the fork + branch that opened the PR
+    - name: Checkout PR head
+      if: github.event_name == 'pull_request'
       uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       with:
-        fetch-depth: 0  # Full history for comprehensive scanning
-        # Ensure we checkout a branch when possible
-        ref: ${{ github.head_ref || github.ref }}
+        repository: ${{ github.event.pull_request.head.repo.full_name }}
+        ref: ${{ github.event.pull_request.head.ref }}
+        fetch-depth: 0
+
+    # Push path: checkout this repo/branch
+    - name: Checkout push ref
+      if: github.event_name != 'pull_request'
+      uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      with:
+        ref: ${{ github.ref }}
+        fetch-depth: 0
 
     - name: Install Gitleaks
       run: |
@@ -82,12 +92,22 @@ jobs:
       contents: read
       security-events: write
     steps:
-    - name: Checkout code
+    # PR path: checkout the fork + branch that opened the PR
+    - name: Checkout PR head
+      if: github.event_name == 'pull_request'
       uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       with:
+        repository: ${{ github.event.pull_request.head.repo.full_name }}
+        ref: ${{ github.event.pull_request.head.ref }}
         fetch-depth: 0
-        # Ensure we checkout a branch when possible to provide base reference
-        ref: ${{ github.head_ref || github.ref }}
+
+    # Push path: checkout this repo/branch
+    - name: Checkout push ref
+      if: github.event_name != 'pull_request'
+      uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      with:
+        ref: ${{ github.ref }}
+        fetch-depth: 0
 
     - name: Set base and head refs for TruffleHog
       id: refs
@@ -137,8 +157,20 @@ jobs:
       contents: read
       security-events: write
     steps:
-    - name: Checkout code
+    # PR path: checkout the fork + branch that opened the PR
+    - name: Checkout PR head
+      if: github.event_name == 'pull_request'
       uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      with:
+        repository: ${{ github.event.pull_request.head.repo.full_name }}
+        ref: ${{ github.event.pull_request.head.ref }}
+
+    # Push path: checkout this repo/branch
+    - name: Checkout push ref
+      if: github.event_name != 'pull_request'
+      uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      with:
+        ref: ${{ github.ref }}
 
     # Custom secret patterns for Ephemos
     - name: Custom Secret Patterns
@@ -176,8 +208,20 @@ jobs:
     name: Configuration Security Audit
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout code
+    # PR path: checkout the fork + branch that opened the PR
+    - name: Checkout PR head
+      if: github.event_name == 'pull_request'
       uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      with:
+        repository: ${{ github.event.pull_request.head.repo.full_name }}
+        ref: ${{ github.event.pull_request.head.ref }}
+
+    # Push path: checkout this repo/branch
+    - name: Checkout push ref
+      if: github.event_name != 'pull_request'
+      uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      with:
+        ref: ${{ github.ref }}
 
     - name: Set up Go
       uses: actions/setup-go@v5
@@ -233,8 +277,20 @@ jobs:
     name: Git-secrets AWS Pattern Scan
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout code
+    # PR path: checkout the fork + branch that opened the PR
+    - name: Checkout PR head
+      if: github.event_name == 'pull_request'
       uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      with:
+        repository: ${{ github.event.pull_request.head.repo.full_name }}
+        ref: ${{ github.event.pull_request.head.ref }}
+
+    # Push path: checkout this repo/branch
+    - name: Checkout push ref
+      if: github.event_name != 'pull_request'
+      uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      with:
+        ref: ${{ github.ref }}
 
     - name: Install git-secrets
       run: |


### PR DESCRIPTION
Updated all workflows that run on pull_request events to properly handle PRs from forks by using the PR head repository and branch:

- performance.yml: Fixed 2 checkout steps in benchmark and memory-profile jobs
- sast-scan.yml: Fixed checkout step in scan job
- docs-and-release.yml: Fixed 3 checkout steps in docs-lint, api-docs, and validate-configs jobs
- secrets-scan.yml: Fixed 5 checkout steps across all scanning jobs

Each checkout now uses conditional logic:
- For pull_request events: uses github.event.pull_request.head.repo.full_name and head.ref
- For push events: uses github.ref

This fixes the error where workflows tried to checkout fork branches from the parent repository instead of the fork repository.

🤖 Generated with [Claude Code](https://claude.ai/code)