### PR TITLE
Add spiffe://test.example.com/* pattern to .gitallowed

### DIFF
--- a/.gitallowed
+++ b/.gitallowed
@@ -6,6 +6,9 @@ spiffe://example\.org/.*
 spiffe://example\.org/[^/]*
 spiffe://test\.example\.org/.*
 
+# SPIFFE test URIs with test.example.com domain
+spiffe://test\.example\.com/.*
+
 # Test SPIFFE patterns with wildcards (for pattern matching tests)
 spiffe://test\.com/.*
 spiffe://test\.local/.*


### PR DESCRIPTION
Fixes git-secrets failure by whitelisting legitimate SPIFFE test URIs that use the test.example.com domain in test files.

🤖 Generated with [Claude Code](https://claude.ai/code)