### PR TITLE
Phase 2: Configuration Refactoring - Capability injection and builder…

### DIFF
--- a/internal/adapters/secondary/config/trust_domain_adapter.go
+++ b/internal/adapters/secondary/config/trust_domain_adapter.go
@@ -1,0 +1,79 @@
+// Package config provides configuration-based implementations of core ports.
+package config
+
+import (
+	"fmt"
+
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
+	"github.com/spiffe/go-spiffe/v2/spiffetls/tlsconfig"
+
+	"github.com/sufield/ephemos/internal/core/ports"
+)
+
+// TrustDomainAdapter provides trust domain capabilities by adapting from configuration.
+// This adapter encapsulates configuration access and provides a clean interface.
+type TrustDomainAdapter struct {
+	config *ports.Configuration
+}
+
+// NewTrustDomainAdapter creates a new trust domain adapter from configuration.
+func NewTrustDomainAdapter(config *ports.Configuration) *TrustDomainAdapter {
+	return &TrustDomainAdapter{
+		config: config,
+	}
+}
+
+// GetTrustDomain returns the configured trust domain as a string.
+func (t *TrustDomainAdapter) GetTrustDomain() (string, error) {
+	if t.config == nil {
+		return "", fmt.Errorf("configuration is nil")
+	}
+
+	if t.config.Service.Domain == "" {
+		return "", fmt.Errorf("trust domain not configured")
+	}
+
+	return t.config.Service.Domain, nil
+}
+
+// CreateDefaultAuthorizer creates a secure default authorizer for the trust domain.
+func (t *TrustDomainAdapter) CreateDefaultAuthorizer() (tlsconfig.Authorizer, error) {
+	trustDomainStr, err := t.GetTrustDomain()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get trust domain: %w", err)
+	}
+
+	// Parse trust domain using go-spiffe
+	trustDomain, err := spiffeid.TrustDomainFromString(trustDomainStr)
+	if err != nil {
+		return nil, fmt.Errorf("invalid trust domain %q: %w", trustDomainStr, err)
+	}
+
+	// Create secure authorizer that only allows members of this trust domain
+	authorizer := tlsconfig.AuthorizeMemberOf(trustDomain)
+	return authorizer, nil
+}
+
+// IsConfigured returns true if a trust domain has been properly configured.
+func (t *TrustDomainAdapter) IsConfigured() bool {
+	if t.config == nil {
+		return false
+	}
+
+	// Check if trust domain is set and valid
+	if t.config.Service.Domain == "" {
+		return false
+	}
+
+	// Validate trust domain format
+	_, err := spiffeid.TrustDomainFromString(t.config.Service.Domain)
+	return err == nil
+}
+
+// ShouldSkipCertificateValidation returns true if certificate validation should be skipped (development only).
+func (t *TrustDomainAdapter) ShouldSkipCertificateValidation() bool {
+	if t.config == nil {
+		return false
+	}
+	return t.config.ShouldSkipCertificateValidation()
+}

--- a/internal/adapters/secondary/transport/factory.go
+++ b/internal/adapters/secondary/transport/factory.go
@@ -6,13 +6,16 @@ import (
 	"github.com/spiffe/go-spiffe/v2/spiffetls/tlsconfig"
 	"github.com/spiffe/go-spiffe/v2/svid/x509svid"
 
+	"github.com/sufield/ephemos/internal/adapters/secondary/config"
 	"github.com/sufield/ephemos/internal/core/ports"
 )
 
 // CreateGRPCProvider creates a rotation-capable gRPC transport provider.
 // If sources are provided, the provider will support automatic SVID rotation.
-func CreateGRPCProvider(config *ports.Configuration, opts ...ProviderOption) (*RotatableGRPCProvider, error) {
-	provider := NewRotatableGRPCProvider(config)
+func CreateGRPCProvider(cfg *ports.Configuration, opts ...ProviderOption) (*RotatableGRPCProvider, error) {
+	// Create trust domain provider using dependency injection
+	trustProvider := config.NewTrustDomainAdapter(cfg)
+	provider := NewRotatableGRPCProvider(trustProvider)
 
 	// Apply options - collect any errors
 	for _, opt := range opts {

--- a/internal/core/ports/configuration_builder.go
+++ b/internal/core/ports/configuration_builder.go
@@ -1,0 +1,109 @@
+// Package ports provides configuration builder for clean configuration construction.
+package ports
+
+import (
+	"fmt"
+
+	"github.com/sufield/ephemos/internal/core/domain"
+)
+
+// ConfigurationBuilder provides a fluent interface for building configurations.
+// This builder pattern improves configuration construction ergonomics and validation.
+type ConfigurationBuilder struct {
+	config *Configuration
+}
+
+// NewConfigurationBuilder creates a new configuration builder.
+func NewConfigurationBuilder() *ConfigurationBuilder {
+	return &ConfigurationBuilder{
+		config: &Configuration{
+			Service: ServiceConfig{},
+			Agent:   &AgentConfig{},
+		},
+	}
+}
+
+// WithService sets the service name and domain.
+func (b *ConfigurationBuilder) WithService(name string, trustDomain string) *ConfigurationBuilder {
+	b.config.Service.Name = domain.NewServiceNameUnsafe(name)
+	b.config.Service.Domain = trustDomain
+	return b
+}
+
+// WithServiceName sets just the service name.
+func (b *ConfigurationBuilder) WithServiceName(name string) *ConfigurationBuilder {
+	b.config.Service.Name = domain.NewServiceNameUnsafe(name)
+	return b
+}
+
+// WithTrustDomain sets just the trust domain.
+func (b *ConfigurationBuilder) WithTrustDomain(domain string) *ConfigurationBuilder {
+	b.config.Service.Domain = domain
+	return b
+}
+
+// WithCacheTTL sets the cache TTL in minutes.
+func (b *ConfigurationBuilder) WithCacheTTL(minutes int) *ConfigurationBuilder {
+	if b.config.Service.Cache == nil {
+		b.config.Service.Cache = &CacheConfig{}
+	}
+	b.config.Service.Cache.TTLMinutes = minutes
+	return b
+}
+
+// WithCacheRefresh sets the proactive refresh time in minutes.
+func (b *ConfigurationBuilder) WithCacheRefresh(minutes int) *ConfigurationBuilder {
+	if b.config.Service.Cache == nil {
+		b.config.Service.Cache = &CacheConfig{}
+	}
+	b.config.Service.Cache.ProactiveRefreshMinutes = minutes
+	return b
+}
+
+// WithAgentSocket sets the agent socket path.
+func (b *ConfigurationBuilder) WithAgentSocket(socketPath string) *ConfigurationBuilder {
+	if b.config.Agent == nil {
+		b.config.Agent = &AgentConfig{}
+	}
+	b.config.Agent.SocketPath = domain.NewSocketPathUnsafe(socketPath)
+	return b
+}
+
+// WithAuthorizedClients sets the authorized client SPIFFE IDs.
+func (b *ConfigurationBuilder) WithAuthorizedClients(clients []string) *ConfigurationBuilder {
+	b.config.Service.AuthorizedClients = clients
+	return b
+}
+
+// WithTrustedServers sets the trusted server SPIFFE IDs.
+func (b *ConfigurationBuilder) WithTrustedServers(servers []string) *ConfigurationBuilder {
+	b.config.Service.TrustedServers = servers
+	return b
+}
+
+// Note: InsecureSkipVerify is controlled via environment variables
+// and is not part of the standard configuration structure for security reasons.
+
+// Build constructs and validates the final configuration.
+func (b *ConfigurationBuilder) Build() (*Configuration, error) {
+	// Validate required fields
+	if b.config.Service.Name.Value() == "" {
+		return nil, fmt.Errorf("service name is required")
+	}
+	
+	if b.config.Service.Domain == "" {
+		return nil, fmt.Errorf("trust domain is required")
+	}
+
+	// Perform full configuration validation
+	if err := b.config.Validate(); err != nil {
+		return nil, fmt.Errorf("configuration validation failed: %w", err)
+	}
+
+	return b.config, nil
+}
+
+// BuildUnsafe constructs the configuration without validation (for testing).
+func (b *ConfigurationBuilder) BuildUnsafe() *Configuration {
+	return b.config
+}

--- a/internal/core/ports/trust_domain_provider.go
+++ b/internal/core/ports/trust_domain_provider.go
@@ -1,0 +1,22 @@
+// Package ports defines trust domain provider capabilities for dependency injection.
+package ports
+
+import "github.com/spiffe/go-spiffe/v2/spiffetls/tlsconfig"
+
+// TrustDomainProvider provides trust domain capabilities without exposing configuration internals.
+// This interface enables capability injection instead of configuration deep access.
+type TrustDomainProvider interface {
+	// GetTrustDomain returns the configured trust domain as a string.
+	GetTrustDomain() (string, error)
+
+	// CreateDefaultAuthorizer creates a secure default authorizer for the trust domain.
+	// Returns an authorizer that verifies certificates belong to the configured trust domain.
+	CreateDefaultAuthorizer() (tlsconfig.Authorizer, error)
+
+	// IsConfigured returns true if a trust domain has been properly configured.
+	IsConfigured() bool
+
+	// ShouldSkipCertificateValidation returns true if certificate validation should be skipped (development only).
+	// This is a security-sensitive operation and should only be used in development environments.
+	ShouldSkipCertificateValidation() bool
+}


### PR DESCRIPTION
… pattern

This commit implements Phase 2 of the long-chain refactoring plan by replacing configuration deep access with capability injection and adding builder patterns.

Changes include:

## New TrustDomainProvider Interface (Recipe 2)
- Extract TrustDomainProvider interface for capability injection
- Provides GetTrustDomain() without exposing config internals
- Includes CreateDefaultAuthorizer() for secure defaults
- Adds ShouldSkipCertificateValidation() for development mode

## TrustDomainAdapter Implementation
- Concrete adapter that wraps configuration access
- Implements all TrustDomainProvider methods
- Encapsulates spiffeid validation and authorizer creation
- Provides clean abstraction over config.Service.Domain access

## Transport Adapter Refactoring
- Update RotatableGRPCProvider to use dependency injection
- Replace p.config.Service.Domain with p.trustProvider.GetTrustDomain()
- Remove all configuration deep access patterns
- Update constructor to accept TrustDomainProvider

## Configuration Builder Pattern (Recipe 6)
- Add ConfigurationBuilder with fluent interface
- Support method chaining: WithService().WithCacheTTL().Build()
- Include validation in Build() method
- Provide BuildUnsafe() for testing scenarios

## Factory Updates
- Update CreateGRPCProvider to inject TrustDomainAdapter
- Maintain backward compatibility with existing configuration parameter
- Use dependency injection pattern throughout

## Test Updates
- Add mockTrustProvider for test scenarios
- Update grpc_rotation_test.go to use new constructor
- Verify all transport tests pass with new architecture

## Before and After Comparison

**Before (Law of Demeter violation):**
```go
if p.config != nil && p.config.Service.Domain != "" {
    if td, err := spiffeid.TrustDomainFromString(p.config.Service.Domain); err == nil {
        return tlsconfig.AuthorizeMemberOf(td)
    }
}
```

**After (Clean capability injection):**
```go
if p.trustProvider != nil {
    if authorizer, err := p.trustProvider.CreateDefaultAuthorizer(); err == nil {
        return authorizer
    }
}
```

This eliminates the config.Service.Domain deep access pattern identified in the refactoring guide and follows dependency injection best practices.

🤖 Generated with [Claude Code](https://claude.ai/code)